### PR TITLE
chore (Github) add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @planningcenter/mobile-engineering


### PR DESCRIPTION
As part of the One Github Dream theme week project, we're going through and adding/updating CODEOWNERS for every repo.

These initial PRs (of which this PR is one) should hopefully be straightforward. The main idea of this project is to capture the state of the world as it is now, and iterate in the future as pain points are felt and code owners are identified.

If there are any questions feel free to ask either here or in [#one-github-dream](https://pco.slack.com/archives/C044X0AHWMP).