### PR TITLE
Hide commit message for EAS production builds

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -179,6 +179,8 @@ const NewBuildMessage = ({
   const { message } = data
   const refString = context.ref.replace('refs/heads/', '')
   const isEasBuild = Boolean(iosBuildUrl || androidBuildUrl)
+  const showCommitMessage = !isEasBuild || type !== 'Production'
+
   const fields = [
     type && `*Type:*\n${type}`,
     number && `*Number:*\n${number}`,
@@ -187,7 +189,7 @@ const NewBuildMessage = ({
     !isEasBuild && `*Triggered by:*\n${actor.name}`,
     `*Ref:*\n<${buildBaseUrl(context)}/tree/${refString}|${refString}>`,
     `*SHA:*\n*<${commit.data.html_url}|${context.sha.slice(-8)}>*`,
-    `*Commit*\n${message}`,
+    showCommitMessage && `*Commit*\n${message}`,
     notes && `*Notes*\n${notes}`,
     !isEasBuild && generateStatusMessage(status),
     !isEasBuild &&


### PR DESCRIPTION
This commit message usually ends up just being "Merge pull request ### from planningcenter/pco-release--internal". We can clean up the Slack message a tad for these particular builds.
